### PR TITLE
fix(cache): replace Exposed Entity API with DSL to prevent cache errors

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -13,7 +13,6 @@ import org.javacs.kt.database.Locations
 import org.javacs.kt.database.Ranges
 import org.javacs.kt.database.Positions
 import org.javacs.kt.database.SymbolIndexMetadata
-import org.javacs.kt.database.SymbolIndexMetadataEntity
 import org.javacs.kt.database.IndexedJars
 import org.javacs.kt.progress.Progress
 import java.nio.file.Path
@@ -114,18 +113,18 @@ class SymbolIndex(
 
         return try {
             transaction(db) {
-                val metadata = SymbolIndexMetadataEntity.all().firstOrNull()
+                val metadata = SymbolIndexMetadata.selectAll().firstOrNull()
                 if (metadata == null) {
                     LOG.debug("No symbol index metadata found, index needs to be rebuilt")
                     false
-                } else if (metadata.buildFileVersion < currentBuildFileVersion) {
-                    LOG.debug("Symbol index is stale (indexed at version ${metadata.buildFileVersion}, current version $currentBuildFileVersion)")
+                } else if (metadata[SymbolIndexMetadata.buildFileVersion] < currentBuildFileVersion) {
+                    LOG.debug("Symbol index is stale (indexed at version ${metadata[SymbolIndexMetadata.buildFileVersion]}, current version $currentBuildFileVersion)")
                     false
-                } else if (metadata.symbolCount == 0) {
+                } else if (metadata[SymbolIndexMetadata.symbolCount] == 0) {
                     LOG.debug("Symbol index is empty, needs to be rebuilt")
                     false
                 } else {
-                    LOG.debug("Symbol index is valid (${metadata.symbolCount} symbols, indexed at version ${metadata.buildFileVersion})")
+                    LOG.debug("Symbol index is valid (${metadata[SymbolIndexMetadata.symbolCount]} symbols, indexed at version ${metadata[SymbolIndexMetadata.buildFileVersion]})")
                     true
                 }
             }

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
@@ -1,14 +1,12 @@
 package org.javacs.kt.classpath
 
 import org.javacs.kt.LOG
-import org.jetbrains.exposed.dao.IntEntity
-import org.jetbrains.exposed.dao.IntEntityClass
-import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -29,26 +27,6 @@ private object BuildScriptClassPathCacheEntry : IntIdTable() {
     val jar = varchar("jar", length = MAX_PATH_LENGTH)
 }
 
-class ClassPathMetadataCacheEntity(id: EntityID<Int>) : IntEntity(id) {
-    companion object : IntEntityClass<ClassPathMetadataCacheEntity>(ClassPathMetadataCache)
-
-    var includesSources by ClassPathMetadataCache.includesSources
-    var buildFileVersion by ClassPathMetadataCache.buildFileVersion
-}
-
-class ClassPathCacheEntryEntity(id: EntityID<Int>) : IntEntity(id) {
-    companion object : IntEntityClass<ClassPathCacheEntryEntity>(ClassPathCacheEntry)
-
-    var compiledJar by ClassPathCacheEntry.compiledJar
-    var sourceJar by ClassPathCacheEntry.sourceJar
-}
-
-class BuildScriptClassPathCacheEntryEntity(id: EntityID<Int>) : IntEntity(id) {
-    companion object : IntEntityClass<BuildScriptClassPathCacheEntryEntity>(BuildScriptClassPathCacheEntry)
-
-    var jar by BuildScriptClassPathCacheEntry.jar
-}
-
 /** A classpath resolver that caches another resolver */
 internal class CachedClassPathResolver(
     private val wrapped: ClassPathResolver,
@@ -58,10 +36,10 @@ internal class CachedClassPathResolver(
 
     private var cachedClassPathEntries: Set<ClassPathEntry>
         get() = transaction(db) {
-            ClassPathCacheEntryEntity.all().map {
+            ClassPathCacheEntry.selectAll().map { row ->
                 ClassPathEntry(
-                    compiledJar = Paths.get(it.compiledJar),
-                    sourceJar = it.sourceJar?.let(Paths::get)
+                    compiledJar = Paths.get(row[ClassPathCacheEntry.compiledJar]),
+                    sourceJar = row[ClassPathCacheEntry.sourceJar]?.let(Paths::get)
                 )
             }.toSet()
         }
@@ -76,7 +54,7 @@ internal class CachedClassPathResolver(
         }
 
     private var cachedBuildScriptClassPathEntries: Set<Path>
-        get() = transaction(db) { BuildScriptClassPathCacheEntryEntity.all().map { Paths.get(it.jar) }.toSet() }
+        get() = transaction(db) { BuildScriptClassPathCacheEntry.selectAll().map { row -> Paths.get(row[BuildScriptClassPathCacheEntry.jar]) }.toSet() }
         set(newEntries) = transaction(db) {
             BuildScriptClassPathCacheEntry.deleteAll()
             newEntries.forEach { entry ->
@@ -86,10 +64,10 @@ internal class CachedClassPathResolver(
 
     private var cachedClassPathMetadata
         get() = transaction(db) {
-            ClassPathMetadataCacheEntity.all().map {
+            ClassPathMetadataCache.selectAll().map { row ->
                 ClasspathMetadata(
-                    includesSources = it.includesSources,
-                    buildFileVersion = it.buildFileVersion
+                    includesSources = row[ClassPathMetadataCache.includesSources],
+                    buildFileVersion = row[ClassPathMetadataCache.buildFileVersion]
                 )
             }.firstOrNull()
         }


### PR DESCRIPTION
## Summary

Exposed ORMのEntity APIは内部キャッシュを持ち、DBの実際の状態と乖離することがある。
これが `ClassPathCacheEntry.id is not in record set` エラーの原因となっていた。

Entity API (`XxxEntity.all()`) をDSL (`XxxTable.selectAll()`) に置き換えることで、
内部キャッシュを経由せず直接DBにアクセスするようになり、この問題を根本的に解決する。

## Scope

- `CachedClassPathResolver` - クラスパスキャッシュの読み取り
- `DatabaseService` - DBバージョン確認
- `SymbolIndex` - シンボルインデックスメタデータの検証

## Test plan

- [x] `./gradlew :server:test` passed
- [x] `./gradlew :server:installDist` passed
- [ ] Manual test: Open a Kotlin project in nvim and verify no cache errors in LSP log