### PR TITLE
fix(definition): resolve external library methods to correct declaring class

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
+++ b/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
@@ -192,15 +192,6 @@ private fun buildClassFilePath(descriptor: DeclarationDescriptor): String? {
         }
     }
 
-    if (descriptor is DeserializedCallableMemberDescriptor) {
-        val source = descriptor.containerSource
-        if (source is KotlinJvmBinarySourceElement) {
-            val classId = source.binaryClass.classId
-            return classId.packageFqName.asString().replace('.', '/') +
-                "/" + classId.relativeClassName.asString().replace('.', '$') + ".class"
-        }
-    }
-
     val containingClass = findContainingClass(descriptor)
     if (containingClass != null) {
         return buildClassFilePathForClass(containingClass)


### PR DESCRIPTION
## Summary

External Java library methods (e.g., jOOQ's `fetchOne`) were not resolving correctly because:

1. Extracted source files in Gradle/Maven caches were not recognized as external sources
2. Inherited methods were resolved to the referencing interface instead of the declaring class

## Changes

- Expand external source detection to include dependency cache directories
- Follow the override chain to find the original method declaration for inherited members

## Testing

- Verified with jOOQ library methods in a multi-module Gradle project
- All existing tests pass

## Notes

Requires `externalSources.useKlsScheme = false` in LSP client configuration for proper display.